### PR TITLE
github workflow to trigger rebuild

### DIFF
--- a/.github/workflows/update-graph.yml
+++ b/.github/workflows/update-graph.yml
@@ -1,0 +1,55 @@
+name: Update Graph
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: #allows manual triggering of the workflow
+
+jobs:
+  update-graph:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout from Github
+        uses: actions/checkout@v4
+
+      - name: Install curl and jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl jq
+
+      - name: Trigger graph update
+        id: graph_update
+        run: |
+          SERVER_HOST="${{ secrets.GRAPH_SERVER_HOST }}"
+
+          # Dynamically get the repository URL
+          REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
+
+          #local testing :  act -j update-graph -P ubuntu-latest=node:16-slim
+          #SERVER_HOST="${SERVER_HOST:-http://host.docker.internal:7777}"
+
+          echo "Using repository: $REPO_URL"
+
+          RESPONSE=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"repo_url\": \"$REPO_URL\"}" \
+            "$SERVER_HOST/process")
+
+          echo "Response: $RESPONSE"
+
+          STATUS=$(echo $RESPONSE | jq -r '.status')
+          MESSAGE=$(echo $RESPONSE | jq -r '.message')
+
+          echo "STATUS=$STATUS" >> $GITHUB_ENV
+          echo "MESSAGE=$MESSAGE" >> $GITHUB_ENV
+
+      - name: Check update status
+        run: |
+          if [ "$STATUS" == "success" ]; then
+            echo "Graph update successful"
+            echo "Message: $MESSAGE"
+          else
+            echo "Graph update failed"
+            echo "Message: $MESSAGE"
+            exit 1
+          fi


### PR DESCRIPTION
 Workflow to trigger graph rebuild. 

- It requires the `GRAPH_SERVER_HOST` to be set from Github Secrets and Variables.